### PR TITLE
container_name 에러

### DIFF
--- a/scale/README.md
+++ b/scale/README.md
@@ -1,0 +1,64 @@
+# 🐳 Docker Compose로 Locust Worker 스케일링 시 컨테이너 이름 충돌 해결
+
+## 개요
+
+프로젝트의 성능 테스트 환경으로 Python 기반의 부하 테스트 도구인 Locust를 사용하였으며, Docker Compose를 이용해 Master-Worker 구조로 구성하고, --scale 옵션을 통해 Worker 다중 배포를 실현하고자 하였습니다.
+
+## 문제 상황
+
+초기 docker-compose.yml 설정에서 다음과 같이 locust-worker 서비스에 container_name을 명시한 상태에서 테스트를 수행했습니다:
+
+```
+  locust-worker:
+    container_name: locust-worker
+    image: locustio/locust
+    ...
+```
+
+```
+docker-compose up --scale locust-worker=3
+```
+
+## 에러 메시지:
+```
+Conflict. The container name "/locust-worker" is already in use by container ...
+```
+
+container_name을 명시할 경우, 해당 이름은 고유해야 하며 `동일 이름의 컨테이너`를 여러 개 생성할 수 없습니다.
+
+--scale은 같은 서비스 정의를 여러 컨테이너로 복제하므로, 정적인 이름이 충돌을 일으킵니다.
+
+## 원인 분석
+
+Docker의 container_name은 단일 컨테이너에만 부여할 수 있는 고유 식별자입니다.
+
+--scale locust-worker=3 명령은 locust-worker_1, locust-worker_2, locust-worker_3과 같이 자동으로 이름을 생성하려 하지만, 수동으로 container_name: locust-worker를 지정하면 `모든 인스턴스가 동일한 이름을 요구`하게 되어 충돌이 발생합니다.
+
+## 해결 방법
+
+container_name을 제거하여 Docker가 각 컨테이너에 자동으로 고유 이름을 부여하도록 
+
+```
+  locust-worker:
+    image: locustio/locust
+    depends_on:
+      - locust-master
+    volumes:
+      - ./:/mnt/locust
+    command: >
+      -f /mnt/locust/locustfile-test.py
+      --worker
+      --master-host locust-master
+```
+```
+docker-compose up --scale locust-worker=3
+```
+
+## 결과
+
+* container_name 설정을 제거함으로써 Locust Worker 컨테이너의 `수평 확장`이 가능해졌습니다.
+
+* 부하 테스트 시스템을 설계하면서 Master-Worker 구조의 통신 방식, 동기화 구조, 확장성까지 함께 고려한 경험을 통해 성능 최적화 및 테스트 자동화 기반을 마련했습니다.
+
+* 컨테이너 이름 충돌은 스케일링 환경에서 자주 발생할 수 있는 실무 이슈이며, 이를 통해 Docker 내부 작동 방식에 대한 깊은 이해했습니다.
+

--- a/scale/docker-compose.scale-with-container-name.yml
+++ b/scale/docker-compose.scale-with-container-name.yml
@@ -1,0 +1,24 @@
+services:
+  locust-master:
+    container_name: locust-master
+    image: locustio/locust
+    ports:
+      - "8089:8089"
+    volumes:
+      - ./:/mnt/locust
+    command: >
+      -f /mnt/locust/locustfile-test.py
+      --master
+      -H http://host.docker.internal:8080
+
+  locust-worker:
+    container_name: locust-worker
+    image: locustio/locust
+    depends_on:
+      - locust-master
+    volumes:
+      - ./:/mnt/locust
+    command: >
+      -f /mnt/locust/locustfile-test.py
+      --worker
+      --master-host locust-master

--- a/scale/docker-compose.scale-without-container-name.yml
+++ b/scale/docker-compose.scale-without-container-name.yml
@@ -1,0 +1,23 @@
+services:
+  locust-master:
+    container_name: locust-master
+    image: locustio/locust
+    ports:
+      - "8089:8089"
+    volumes:
+      - ./:/mnt/locust
+    command: >
+      -f /mnt/locust/locustfile-test.py
+      --master
+      -H http://host.docker.internal:8080
+
+  locust-worker:
+    image: locustio/locust
+    depends_on:
+      - locust-master
+    volumes:
+      - ./:/mnt/locust
+    command: >
+      -f /mnt/locust/locustfile-test.py
+      --worker
+      --master-host locust-master

--- a/scale/locustfile-test.py
+++ b/scale/locustfile-test.py
@@ -1,0 +1,12 @@
+from locust import task, FastHttpUser, stats
+
+stats.PERCENTILES_TO_CHART = [0.95, 0.99]
+
+class Test(FastHttpUser):
+    connection_timeout = 10.0
+    network_timeout = 10.0
+
+    @task
+    def test(self):
+        response = self.client.get("/test")
+


### PR DESCRIPTION
## PR 제목

Locust Master-Worker 부하 테스트 환경 및 컨테이너 이름 충돌 해결

## 개요

Locust 부하 테스트 환경을 Docker Compose 기반 Master-Worker 구조로 구성하고, --scale 옵션 사용 시 발생하는 container_name 충돌 문제를 해결했습니다.

## 주요 변경 사항
locustfile-test.py 작성
* FastHttpUser 기반 /test GET 요청 시나리오 정의
* 응답 퍼센타일 차트 설정(95%, 99%)

docker-compose.scale-with-container-name.yml
* 초기 구성: locust-worker에 고정 container_name 설정 → 다중 스케일링 시 충돌

docker-compose.scale-without-container-name.yml
* 개선 구성: container_name 제거 → --scale locust-worker=N 명령 사용 가능

scale/README.md 문서 작성
* 문제 재현, 원인 분석, 해결 방법 및 결과 정리
* Docker Compose의 container 네이밍 규칙과 스케일링 구조 이해 기반 설명 포함

## 테스트 및 검증

--scale locust-worker=3 실행 시 container_name 제거 버전은 정상 작동 확인
웹 UI(localhost:8089)에서 부하 테스트 시 여러 워커 간 분산 요청 처리 확인
문제 상황과 해결 방법을 문서화하고 실무 관점의 인사이트 도출

## 기타 사항
* Locust Master-Worker 구성은 대규모 트래픽 시나리오 테스트에 활용 가능
* container 이름 충돌 문제는 실제 운영 환경에서도 자주 발생하는 실무 이슈로, 이 경험을 통해 Docker Compose의 스케일링 전략 및 이름 관리 메커니즘에 대한 깊은 이해를 확보함

* * *

This closes #3 